### PR TITLE
replace broken switch statement with object key check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 .DS_Store
 .build
+.jshintrc
 .idea
 dist/*
 .vscode

--- a/src/template/shared/unitlessProperties.js
+++ b/src/template/shared/unitlessProperties.js
@@ -1,40 +1,52 @@
-export default (str) => {
-    switch (str.length) {
-        case 4:
-            return str === 'flex' || str === 'base' || str === 'zoom';
-        case 5:
-            return str === 'order';
-        case 6:
-            return str === 'marker' || str === 'stress' || str === 'volume' || str === 'widows' || str === 'zIndex';
-        case 7:
-            return str === 'boxFlex' || str === 'gridRow' || str === 'opacity' || str === 'orphans' || str === 'tabSize';
-        case 8:
-            return str === 'flexGrow' || str === 'richness';
-        case 9:
-            return str === 'flexOrder' || str === 'lineClamp' || 'msBoxFlex';
-        case 10:
-            return str === 'flexShrink' || str === 'counterReset' || str === 'fontWeight' || str === 'gridColumn' || str === 'lineHeight' || str === 'pitchRange' || str === 'MozBoxFlex';
-        case 11:
-            return str === 'columnCount' || str === 'counterReset' || str === 'stopOpacity' || str === 'fillOpacity' || str === 'strokeWidth';
-        case 12:
-            return str === 'boxFlexGroup' || str === 'counterReset' || str === 'flexPositive' || str === 'flexNegative';
-        case 13:
-            return str === 'strokeOpacity' || str === 'WebkitBoxFlex' || str === 'WebkitGridRow';
-        case 14:
-            return str === 'WebkitFlexGrow';
-        case 15:
-            return str === 'boxOrdinalGroup' || str === 'WebkitFlexShrink';
-        case 16:
-            return str === 'counterIncrement' || str === 'strokeDashoffset';
-        case 17:
-            return str === 'MozBoxOrdinalGroup' || str === 'WebkitStrokeWidth';
-        case 20:
-            return str === 'WebkitBoxOrdinalGroup';
-        case 23:
-            return str === 'animationIterationCount';
-        case 29:
-            return str === 'WebkitAnimationIterationCount';
-    }
+const unitlessProps = {
+    flex: true,
+    base: true,
+    zoom: true,
+    order: true,
+    marker: true,
+    stress: true,
+    volume: true,
+    widows: true,
+    zIndex: true,
+    boxFlex: true,
+    gridRow: true,
+    opacity: true,
+    orphans: true,
+    tabSize: true,
+    flexGrow: true,
+    richness: true,
+    flexOrder: true,
+    lineClamp: true,
+    msBoxFlex: true,
+    flexShrink: true,
+    fontWeight: true,
+    gridColumn: true,
+    lineHeight: true,
+    pitchRange: true,
+    MozBoxFlex: true,
+    columnCount: true,
+    stopOpacity: true,
+    fillOpacity: true,
+    strokeWidth: true,
+    boxFlexGroup: true,
+    counterReset: true,
+    flexPositive: true,
+    flexNegative: true,
+    strokeOpacity: true,
+    WebkitBoxFlex: true,
+    WebkitGridRow: true,
+    WebkitFlexGrow: true,
+    boxOrdinalGroup: true,
+    WebkitFlexShrink: true,
+    counterIncrement: true,
+    strokeDashoffset: true,
+    WebkitStrokeWidth: true,
+    MozBoxOrdinalGroup: true,
+    WebkitBoxOrdinalGroup: true,
+    animationIterationCount: true,
+    WebkitAnimationIterationCount: true
+};
 
-    return false;
+export default (str) => {
+  return str in unitlessProps;
 };


### PR DESCRIPTION
The switch statement here was not working correctly:

1) Some values were redundant, for example counterReset is repeated in case 10, 11, and 12 even though only 12 could return true.
2) Some values were unreachable, for example MozBoxOrdinalGroup has length 18 but is inside case 17.
3) Inconsistent return value: 'msBoxFlex' returned directly as a string, all other cases return boolean true/false.

Checking str in unitlessProps is around 10x faster, see http://jsperf.com/1d6109d30b110ee2a27dbb30fa4d1ad9 for direct comparison.