### PR TITLE
Throw error for children passed in as Components not templates.

### DIFF
--- a/src/DOM/domMutate.js
+++ b/src/DOM/domMutate.js
@@ -230,6 +230,9 @@ export function createVirtualList( value, item, childNodeList, treeLifecycle, co
 				keyedChildren = false;
 				childDomNode = childNode.create( item, treeLifecycle, context );
 				childNodeList.push( childDomNode );
+				if ( childDomNode === undefined ) {
+					throw Error('Inferno Error: Children must be provided as templates.');
+				}			
 				domNode.appendChild( childDomNode );
 				break;
 			case ValueTypes.FRAGMENT:

--- a/test/specs/jsx/old/components.spec.browser.js
+++ b/test/specs/jsx/old/components.spec.browser.js
@@ -81,6 +81,12 @@ describe( 'Components (JSX)', () => {
 		}
 	}
 
+	class BasicComponent1c extends Inferno.Component {
+		render() {
+			return (<span>Hello World</span>);
+		}
+	}
+
 	it('should render a basic component with inputs', () => {
 
 		Inferno.render((
@@ -259,6 +265,18 @@ describe( 'Components (JSX)', () => {
 		).to.equal(
 			'<div><div class="basic"><span class="basic-update">The title is 123</span><span>Im a child</span></div></div>'
 		);
+	});
+
+	it('should throw error when a component is included as a child without a template', () => {
+		
+		expect(() => Inferno.render((
+			<div>
+				<BasicComponent2 title="abc" name="basic-render">
+					<span>A child</span>
+					<BasicComponent1c/>
+				</BasicComponent2>
+			</div>
+		), container)).to.throw('Inferno Error: Children must be provided as templates.');
 	});
 
 	it('should render multiple components', () => {


### PR DESCRIPTION
May not be the best way to handle this, but at least provides a nice error message back to the source for this.

Added informative error message when children contain Components.
Added test for error thrown when children contain Components.