### PR TITLE
Changes required to download inferno src folder as a npm git-url dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,12 @@
     "webpack-dev-server": "^1.14.0",
     "inferno-component": "^0.5.13"
   },
-  "files": ["."],
+  "files": [
+    "config", 
+    "src", 
+    "tools", 
+    ".babelrc"
+  ],
   "homepage": "https://github.com/trueadm/inferno#readme",
   "jsnext:main": "src/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -56,12 +56,7 @@
     "webpack-dev-server": "^1.14.0",
     "inferno-component": "^0.5.13"
   },
-  "files": [
-    "config", 
-    "src", 
-    "tools", 
-    ".babelrc"
-  ],
+  "files": ["src"],
   "homepage": "https://github.com/trueadm/inferno#readme",
   "jsnext:main": "src/index.js",
   "keywords": [
@@ -94,7 +89,6 @@
     "build:inferno:dev": "node config/rollup.config.js dev packages/inferno/dist packages/inferno/src inferno Inferno",
     "build:inferno:prod": "node config/rollup.config.js prod packages/inferno/dist packages/inferno/src inferno Inferno",
     "build": "npm run build:inferno-dom:dev && npm run build:inferno-dom:prod && npm run build:inferno:dev && npm run build:inferno:prod && npm run build:inferno-server:dev && npm run build:inferno-server:prod && npm run build:inferno-component:dev && npm run build:inferno-component:prod",
-    "postinstall-out": "npm run build",
     "browser": "webpack-dev-server --quiet --config config/webpack.dev.conf.js --host 0.0.0.0",
     "test:server": "mocha --opts config/mocha.opts",
     "test:browser": "karma start config/karma.conf.js --single-run",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "inferno-all",
   "license": "MPL-2.0",
   "version": "0.5.14",
   "author": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "webpack-dev-server": "^1.14.0",
     "inferno-component": "^0.5.13"
   },
-  "files": "*",
+  "files": ["."],
   "homepage": "https://github.com/trueadm/inferno#readme",
   "jsnext:main": "src/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "files": [
     "dist",
+    "src",
     "README.md"
   ],
   "homepage": "https://github.com/trueadm/inferno#readme",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "build:inferno:dev": "node config/rollup.config.js dev packages/inferno/dist packages/inferno/src inferno Inferno",
     "build:inferno:prod": "node config/rollup.config.js prod packages/inferno/dist packages/inferno/src inferno Inferno",
     "build": "npm run build:inferno-dom:dev && npm run build:inferno-dom:prod && npm run build:inferno:dev && npm run build:inferno:prod && npm run build:inferno-server:dev && npm run build:inferno-server:prod && npm run build:inferno-component:dev && npm run build:inferno-component:prod",
-    "postinstall": "npm run build",
+    "postinstall-out": "npm run build",
     "browser": "webpack-dev-server --quiet --config config/webpack.dev.conf.js --host 0.0.0.0",
     "test:server": "mocha --opts config/mocha.opts",
     "test:browser": "karma start config/karma.conf.js --single-run",

--- a/package.json
+++ b/package.json
@@ -56,11 +56,7 @@
     "webpack-dev-server": "^1.14.0",
     "inferno-component": "^0.5.13"
   },
-  "files": [
-    "dist",
-    "src",
-    "README.md"
-  ],
+  "files": "*",
   "homepage": "https://github.com/trueadm/inferno#readme",
   "jsnext:main": "src/index.js",
   "keywords": [
@@ -93,7 +89,7 @@
     "build:inferno:dev": "node config/rollup.config.js dev packages/inferno/dist packages/inferno/src inferno Inferno",
     "build:inferno:prod": "node config/rollup.config.js prod packages/inferno/dist packages/inferno/src inferno Inferno",
     "build": "npm run build:inferno-dom:dev && npm run build:inferno-dom:prod && npm run build:inferno:dev && npm run build:inferno:prod && npm run build:inferno-server:dev && npm run build:inferno-server:prod && npm run build:inferno-component:dev && npm run build:inferno-component:prod",
-    "postinstall-out": "npm run build",
+    "postinstall": "npm run build",
     "browser": "webpack-dev-server --quiet --config config/webpack.dev.conf.js --host 0.0.0.0",
     "test:server": "mocha --opts config/mocha.opts",
     "test:browser": "karma start config/karma.conf.js --single-run",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inferno-all",
+  "name": "inferno-src",
   "license": "MPL-2.0",
   "version": "0.5.14",
   "author": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "build:inferno:dev": "node config/rollup.config.js dev packages/inferno/dist packages/inferno/src inferno Inferno",
     "build:inferno:prod": "node config/rollup.config.js prod packages/inferno/dist packages/inferno/src inferno Inferno",
     "build": "npm run build:inferno-dom:dev && npm run build:inferno-dom:prod && npm run build:inferno:dev && npm run build:inferno:prod && npm run build:inferno-server:dev && npm run build:inferno-server:prod && npm run build:inferno-component:dev && npm run build:inferno-component:prod",
-    "postinstall": "npm run build",
+    "postinstall-out": "npm run build",
     "browser": "webpack-dev-server --quiet --config config/webpack.dev.conf.js --host 0.0.0.0",
     "test:server": "mocha --opts config/mocha.opts",
     "test:browser": "karma start config/karma.conf.js --single-run",


### PR DESCRIPTION
I had to remove postinstall build step as dev dependencies are not installed on package install. You should decide if this is acceptable.

README.md and LICENSE.md files are always included so I removed that too.

