### PR TITLE
Fixed import statement on for inferno-component in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Furthermore, Inferno also uses ES6 components like React:
 
 ```javascript
 import Inferno from 'inferno';
-import { Component } from `inferno-component`;
+import Component from 'inferno-component';
 import InfernoDOM from 'inferno-dom';
 
 class MyComponent extends Component {


### PR DESCRIPTION
At one point in README.md, to import Component from inferno-component looks like this:

import { Component } from `inferno-component`;

This isn't right, the correct version, used at two other places in the README.md is: 

import Component from 'inferno-component';

Looks like this was a remnant of an older version of the API, but it doesn't work anymore, as Component is the default export from inferno-component.