### PR TITLE
Changed links in README.md to cdnjs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,15 @@ Server-side rendering package:
 npm install --save inferno-server 
 ```
 
-Pre-bundled files for browser consumption:
+Pre-bundled files for browser consumption can be found on [our cdnjs](https://cdnjs.com/libraries/inferno):
  
 ```
-http://infernojs.org/releases/0.7.8/inferno.min.js
-http://infernojs.org/releases/0.7.8/inferno-create-element.min.js
-http://infernojs.org/releases/0.7.8/inferno-component.min.js
-http://infernojs.org/releases/0.7.8/inferno-dom.min.js
-http://infernojs.org/releases/0.7.8/inferno-server.min.js
+https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-component.min.js
+https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-create-element.min.js
+https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-dom.min.js
+https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-server.min.js
+https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-test-utils.min.js
+https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno.min.js
 ```
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ npm install --save inferno-server
 Pre-bundled files for browser consumption can be found on [our cdnjs](https://cdnjs.com/libraries/inferno):
  
 ```
-https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-component.min.js
+https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno.min.js
 https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-create-element.min.js
+https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-component.min.js
 https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-dom.min.js
 https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-server.min.js
 https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno-test-utils.min.js
-https://cdnjs.cloudflare.com/ajax/libs/inferno/0.7.9/inferno.min.js
 ```
 
 ## Overview


### PR DESCRIPTION
Links README.md are now to cdnjs.com, which is SSL by default and allows people to use script tags straight to he CDN from jsfiddle or any other HTTPS enabled site.

Hope you don't mind me pull requesting straight to master, but I feel like it's okay here since no code is changing.