### PR TITLE
pass context to component instantiation

### DIFF
--- a/src/server/renderToString.js
+++ b/src/server/renderToString.js
@@ -16,7 +16,7 @@ function renderComponent(Component, props, children, context, isRoot) {
 	props = addChildrenToProps(children, props);
 
 	if (isStatefulComponent(Component)) {
-		const instance = new Component(props);
+		const instance = new Component(props, context);
 		const childContext = instance.getChildContext();
 
 		if (!isNullOrUndefined(childContext)) {

--- a/src/server/renderToString.js
+++ b/src/server/renderToString.js
@@ -31,7 +31,7 @@ function renderComponent(Component, props, children, context, isRoot) {
 		instance._pendingSetState = false;
 		return renderNode(node, context, isRoot);
 	} else {
-		return renderNode(Component(props), context, isRoot);
+		return renderNode(Component(props, context), context, isRoot);
 	}
 }
 


### PR DESCRIPTION
The gist of the change is to pass the context to components on server rendering as it's done in client-side rendering (https://github.com/trueadm/inferno/blob/master/src/DOM/patching.js#L609)

It's a fix for the issue: https://github.com/trueadm/inferno/issues/293 and one more with `inferno-redux/connect` that is not reported yet