### PR TITLE
Fix for make connect works

### DIFF
--- a/src/DOM/mounting.js
+++ b/src/DOM/mounting.js
@@ -297,7 +297,7 @@ export function mountComponent(parentNode, Component, props, hooks, children, la
 
 	let dom;
 	if (isStatefulComponent(Component)) {
-		const instance = new Component(props);
+		const instance = new Component(props, context);
 
 		instance._patch = patch;
 		instance._componentToDOMNodeMap = componentToDOMNodeMap;

--- a/src/redux/connect.js
+++ b/src/redux/connect.js
@@ -75,7 +75,7 @@ export default function connect(mapStateToProps, mapDispatchToProps, mergeProps,
 				super(props, context);
 
 				this.version = version;
-				this.store = props.store || context.store;
+				this.store = (props && props.store) || (context && context.store);
 
 				invariant(this.store,
 					'Could not find "store" in either the context or ' +


### PR DESCRIPTION
In addition to this commit https://github.com/trueadm/inferno/pull/295/commits/599f8baa5574b3a1362089e5a5f0ba4ebbf21437
also pass a context to component in browser and also check that props or context exists in connect function. Without this checking it causes an issue. When component doesn't take any props the props is null so in connect: 78 it fall with error.