### PR TITLE
Allow setting className, activeClassName and activeStyle on <Link>

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+indent_style = tab
+indent_size = 4

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -10,7 +10,7 @@ module.exports = function (config) {
 			'mocha'
 		],
 		files: [
-            './../node_modules/babel-polyfill/dist/polyfill.js',
+			'./../node_modules/babel-polyfill/dist/polyfill.js',
 			'./../node_modules/sinon/pkg/sinon.js',
             './../src/**/__tests__/**'
 		],
@@ -42,6 +42,7 @@ module.exports = function (config) {
 						loader: 'babel-loader',
 						exclude: /node_modules/,
 						query: {
+							compact: false,
 							presets: ['es2015'],
 							plugins: [
 								'transform-object-rest-spread',

--- a/src/DOM/__tests__/hooks.spec.jsx.js
+++ b/src/DOM/__tests__/hooks.spec.jsx.js
@@ -76,7 +76,7 @@ describe('Components (JSX)', () => {
 				}
 			}
 
-			class D extends Component {			
+			class D extends Component {
 				render() {
 					return (
 						<div>

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -28,7 +28,7 @@ export function isArray(obj) {
 }
 
 export function isStatefulComponent(obj) {
-	return obj.prototype.render !== undefined;
+	return obj.prototype && obj.prototype.render !== undefined;
 }
 
 export function isStringOrNumber(obj) {

--- a/src/router/Link.js
+++ b/src/router/Link.js
@@ -1,8 +1,23 @@
 import { createVNode } from '../core/shapes';
 import { convertToHashbang } from './utils';
 
-export default function Link({ to, children }, { hashbang, history }) {
-	return (createVNode().setAttrs({
-		href: hashbang ? history.getHashbangRoot() + convertToHashbang('#!' + to) : to
-	}).setTag('a').setChildren(children));
+export default function Link(props, { hashbang, history }) {
+	const { activeClassName, activeStyle, className, to } = props;
+	const element = createVNode();
+	const href = hashbang ? history.getHashbangRoot() + convertToHashbang('#!' + to) : to;
+
+	if (className) {
+		element.setClassName(className);
+	}
+
+	if (history.isActive(to, hashbang)) {
+		if (activeClassName) {
+			element.setClassName((className ? className + ' ' : '') + activeClassName);
+		}
+		if (activeStyle) {
+			element.setStyle(Object.assign({}, props.style, activeStyle));
+		}
+	}
+
+	return element.setTag('a').setAttrs({ href }).setChildren(props.children);
 }

--- a/src/router/__tests__/link.spec.jsx.js
+++ b/src/router/__tests__/link.spec.jsx.js
@@ -1,0 +1,85 @@
+import { render } from './../../DOM/rendering';
+import Router from '../Router';
+import Route from '../Route';
+import Link from '../Link';
+import browserHistory from '../browserHistory';
+import { createBlueprint } from './../../core/shapes';
+
+const hashbang = false;
+const rootURL = location.pathname;
+const Inferno = {
+	createBlueprint
+};
+
+function createLink(component, container) {
+	render(
+		<Router url={ rootURL } history={ browserHistory } hashbang={ hashbang }>
+			<Route path={ '*' } component={ component }/>
+		</Router>,
+		container
+	);
+}
+
+describe('Link tests (jsx)', () => {
+	let container;
+
+	beforeEach(() => {
+		container = document.createElement('div');
+	});
+
+	afterEach(() => {
+		render(null, container);
+		container.innerHTML = '';
+	});
+
+	describe('className', () => {
+		it('it should render <a> with a className', () => {
+			createLink(
+				() => <Link to={ rootURL } className={ 'my-css-class' }>Test</Link>,
+				container
+			);
+			const element = container.querySelector('a')
+			expect(element.className).to.equal('my-css-class');
+		});
+	});
+
+	describe('activeStyle', () => {
+		it('it should render <a> with an activeStyle', () => {
+			createLink(
+				() => <Link to={ rootURL } activeStyle={{ color: 'red' }}>Red text</Link>,
+				container
+			);
+			const element = container.querySelector('a')
+			expect(element.style.color).to.equal('red');
+		});
+
+		it('it should NOT render <a> with an activeStyle', () => {
+			createLink(
+				() => <Link to={ '/invalid' } activeStyle={{ color: 'red' }}>Red text</Link>,
+				container
+			);
+			const element = container.querySelector('a')
+			expect(element.style.color).to.not.equal('red');
+		});
+	});
+
+	describe('activeClassName', () => {
+		it('it should render <a> with an activeClassName', () => {
+			createLink(
+				() => <Link to={ rootURL } activeClassName={ 'my-active-class' }>Test</Link>,
+				container
+			);
+			const element = container.querySelector('a')
+			expect(element.className).to.equal('my-active-class');
+		});
+
+		it('it should NOT render <a> with an activeClassName', () => {
+			createLink(
+				() => <Link to={ '/invalid' } activeClassName={ 'my-active-class' }>Test</Link>,
+				container
+			);
+			const element = container.querySelector('a')
+			expect(element.className).to.not.equal('my-active-class');
+		});
+	});
+});

--- a/src/router/browserHistory.js
+++ b/src/router/browserHistory.js
@@ -14,6 +14,16 @@ function getHashbangRoot() {
 	return `${url.protocol + '//' || ''}${url.host || ''}${url.pathname || ''}${url.search || ''}#!`;
 }
 
+function isActive(path, hashbang) {
+	if (hashbang) {
+		var currentURL = getCurrentUrl() + (getCurrentUrl().indexOf('#!') === -1 ? '#!' : '');
+		var matchURL = currentURL.match(/#!(.*)/);
+		var matchHash = matchURL && typeof matchURL[1] !== 'undefined' && (matchURL[1] || '/');
+		return matchHash === path;
+	}
+	return location.pathname === path;
+}
+
 function routeTo(url) {
 	let didRoute = false;
 	for (let i = 0; i < routers.length; i++) {
@@ -36,5 +46,6 @@ export default {
 		routers.splice(routers.indexOf(router), 1);
 	},
 	getCurrentUrl,
-	getHashbangRoot
+	getHashbangRoot,
+	isActive
 };


### PR DESCRIPTION
Allow setting className, activeClassName and activeStyle on <Link>
Added tests for <Link>
Added .editorconfig for webstorm users
(Quick Fix) isStatefulComponent() crashing when a component declared with an arrow function is used (might be a deeper issue, I'll have to look into this)