### PR TITLE
Feature : Render as stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.11.6",
     "chai": "^3.5.0",
+    "concat-stream": "^1.5.1",
     "coveralls": "^2.11.12",
     "cross-env": "^2.0.0",
     "eslint": "^3.2.2",

--- a/packages/inferno-server/src/index.js
+++ b/packages/inferno-server/src/index.js
@@ -1,7 +1,10 @@
 import renderToString, { renderToStaticMarkup } from '../../../src/server/renderToString';
+import streamAsString, { RenderStream, streamAsStaticMarkup } from '../../../src/server/renderToString.stream';
 
 export default {
 	renderToString,
-	renderToStaticMarkup
+	renderToStaticMarkup,
+	streamAsString,
+	streamAsStaticMarkup,
+	RenderStream
 };
-

--- a/src/server/__tests__/creation-stream.spec.browser.js
+++ b/src/server/__tests__/creation-stream.spec.browser.js
@@ -1,0 +1,245 @@
+import renderStream from './../renderToString.stream';
+import concatStream from 'concat-stream';
+import Component from './../../component/es2015';
+import { createBlueprint } from './../../core/shapes';
+
+class StatefulComponent extends Component {
+	render() {
+		return {
+			tag: 'span',
+			children: `stateless ${ this.props.value }!`
+		};
+	}
+}
+
+describe('SSR Creation - (non-JSX)', () => {
+	[
+		{
+			description: 'should render div with span child',
+			template: () => {
+				return {
+					tag: 'div',
+					children: {
+						dom: null,
+						tag: 'span'
+					}
+				};
+			},
+			result: '<div><span></span></div>'
+		}, {
+			description: 'should render div with span child and styling',
+			template: () => {
+				return {
+					tag: 'div',
+					children: {
+						dom: null,
+						tag: 'span',
+						style: 'border-left: 10px;'
+					}
+				};
+			},
+			result: '<div><span style="border-left: 10px;"></span></div>'
+		}, {
+			description: 'should render div with span child and styling #2',
+			template: () => {
+				return {
+					tag: 'div',
+					children: {
+						dom: null,
+						tag: 'span',
+						style: { borderLeft: 10 }
+					}
+				};
+			},
+			result: '<div><span style="border-left:10px;"></span></div>'
+		}, {
+			description: 'should render div with span child and styling #3',
+			template: () => {
+				return {
+					tag: 'div',
+					children: {
+						dom: null,
+						tag: 'span',
+						style: { fontFamily: 'Arial' }
+					}
+				};
+			},
+			result: '<div><span style="font-family:Arial;"></span></div>'
+		}, {
+			description: 'should render div with span child (with className)',
+			template: () => {
+				return {
+					tag: 'div',
+					className: 'foo',
+					children: {
+						dom: null,
+						className: 'bar',
+						tag: 'span'
+					}
+				};
+			},
+			result: '<div class="foo"><span class="bar"></span></div>'
+		}, {
+			description: 'should render div with text child',
+			template: () => {
+				return {
+					tag: 'div',
+					children: 'Hello world'
+				};
+			},
+			result: '<div>Hello world</div>'
+		}, {
+			description: 'should render div with text child (XSS script attack)',
+			template: () => {
+				return {
+					tag: 'div',
+					children: 'Hello world <img src="x" onerror="alert(\'XSS\')">'
+				};
+			},
+			result: '<div>Hello world &lt;img src=&quot;x&quot; onerror=&quot;alert(&#039;XSS&#039;)&quot;&gt;</div>'
+		}, {
+			description: 'should render div with text children',
+			template: () => {
+				return {
+					tag: 'div',
+					children: [ 'Hello', ' world' ]
+				};
+			},
+			result: '<div>Hello<!----> world</div>'
+		}, {
+			description: 'should render a void element correct',
+			template: () => {
+				return {
+					tag: 'input'
+				};
+			},
+			result: '<input>'
+		}, {
+			description: 'should render div with node children',
+			template: () => {
+				return {
+					tag: 'div',
+					children: [
+						{
+							tag: 'span',
+							children: 'Hello'
+						},
+						{
+							tag: 'span',
+							children: ' world!'
+						}
+					]
+				};
+			},
+			result: '<div><span>Hello</span><span> world!</span></div>'
+		}, {
+			description: 'should render div with node children #2',
+			template: () => {
+				return {
+					tag: 'div',
+					children: [
+						{
+							tag: 'span',
+							children: 'Hello',
+							attrs: {
+								id: '123'
+							}
+						},
+						{
+							tag: 'span',
+							children: ' world!',
+							className: 'foo'
+						}
+					]
+				};
+			},
+			result: '<div><span id="123">Hello</span><span class="foo"> world!</span></div>'
+		}, {
+			description: 'should render div with falsy children',
+			template: () => {
+				return {
+					tag: 'div',
+					children: 0
+				};
+			},
+			result: '<div>0</div>'
+		}, {
+			description: 'should render div with dangerouslySetInnerHTML',
+			template: () => {
+				return {
+					tag: 'div',
+					attrs: {
+						dangerouslySetInnerHTML: { __html: '<span>test</span>' }
+					}
+				};
+			},
+			result: '<div><span>test</span></div>'
+		}, {
+			description: 'should render a stateful component',
+			template: (value) => {
+				return {
+					tag: 'div',
+					children: {
+						tag: StatefulComponent,
+						attrs: {
+							value
+						}
+					}
+				};
+			},
+			result: '<div><span>stateless foo!</span></div>'
+		}, {
+			description: 'should render a stateless component',
+			template: (value) => {
+				return {
+					tag: 'div',
+					children: {
+						tag: ({ value }) => ({
+							tag: 'span',
+							children: `stateless ${ value }!`
+						}),
+						attrs: {
+							value
+						}
+					}
+				};
+			},
+			result: '<div><span>stateless foo!</span></div>'
+		}
+	].forEach(test => {
+		it(test.description, () => {
+			const container = document.createElement('div');
+			const vDom = test.template('foo');
+			return streamPromise(vDom).then(function (output) {
+				document.body.appendChild(container);
+				container.innerHTML = output;
+				expect(output).to.equal(test.result);
+				document.body.removeChild(container);
+			});
+		});
+	});
+	it('should not duplicate attrs', () => {
+		const tpl = createBlueprint({
+			tag: 'div',
+			attrs: { id: 'test' }
+		});
+
+		return Promise.all([
+			streamPromise(tpl()),
+			streamPromise(tpl()),
+			streamPromise(tpl())
+		]).then(function (results) {
+			expect(results[ 0 ] === results[ 1 ] && results[ 1 ] === results[ 2 ]).to.equal(true);
+		});
+	});
+});
+
+function streamPromise(dom) {
+	return new Promise(function (res, rej) {
+		renderStream(dom)
+		.on('error', rej)
+		.pipe(concatStream(function (buffer) {
+			res(buffer.toString('utf-8'));
+		}));
+	});
+}

--- a/src/server/prop-renderers.js
+++ b/src/server/prop-renderers.js
@@ -1,0 +1,53 @@
+import {
+	isStringOrNumber,
+	isNullOrUndefined,
+	isNumber
+} from './../core/utils';
+import { isUnitlessNumber } from '../DOM/utils';
+import { toHyphenCase, escapeAttr } from './utils';
+
+export function renderStyleToString(style) {
+	if (isStringOrNumber(style)) {
+		return style;
+	} else {
+		const styles = [];
+		const keys = Object.keys(style);
+
+		for (let i = 0; i < keys.length; i++) {
+			const styleName = keys[i];
+			const value = style[styleName];
+			const px = isNumber(value) && !isUnitlessNumber[styleName] ? 'px' : '';
+
+			if (!isNullOrUndefined(value)) {
+				styles.push(`${ toHyphenCase(styleName) }:${ escapeAttr(value) }${ px };`);
+			}
+		}
+		return styles.join();
+	}
+}
+
+export function renderAttributes(bp, attrs){
+	const outputAttrs = [];
+	let attrKeys = (attrs && Object.keys(attrs)) || [];
+	let html = '';
+
+	if (bp && bp.hasAttrs === true) {
+		attrKeys = bp.attrKeys ? bp.attrKeys.concat(attrKeys) : attrKeys;
+	}
+	attrKeys.forEach((attrsKey, i) => {
+		const attr = attrKeys[i];
+		const value = attrs[attr];
+
+		if (attr === 'dangerouslySetInnerHTML') {
+			return;
+		} else {
+			if (isStringOrNumber(value)) {
+				outputAttrs.push(escapeAttr(attr) + '="' + escapeAttr(value) + '"');
+			} else if (isTrue(value)) {
+				outputAttrs.push(escapeAttr(attr));
+			}
+		}
+	});
+
+	return outputAttrs;
+}

--- a/src/server/renderToString.stream.js
+++ b/src/server/renderToString.stream.js
@@ -1,0 +1,171 @@
+import {
+	isArray,
+	isStringOrNumber,
+	isNullOrUndefined,
+	isInvalidNode,
+	isFunction,
+	addChildrenToProps,
+	isStatefulComponent,
+	isNumber,
+	isTrue
+} from './../core/utils';
+import { isUnitlessNumber } from '../DOM/utils';
+import { toHyphenCase, escapeText, escapeAttr, isVoidElement } from './utils';
+import { Readable } from 'stream';
+import { renderStyleToString, renderAttributes } from './prop-renderers';
+
+export class RenderStream extends Readable {
+	constructor(initNode, staticMarkup) {
+		super();
+		this.initNode = initNode;
+		this.staticMarkup = staticMarkup;
+		this.started = false;
+	}
+
+	_read(){
+		if (this.started) {
+			return;
+		}
+		this.started = true;
+
+		Promise.resolve().then(() =>{
+			return this.renderNode(this.initNode, null, this.staticMarkup);
+		}).then(()=>{
+			this.push(null);
+		}).catch((err) =>{
+			this.emit('error', err);
+		});
+	}
+
+	renderNode(node, context, isRoot){
+		if (isInvalidNode(node)) {
+			return;
+		}
+
+		const bp = node.bp;
+		const tag = node.tag || (bp && bp.tag);
+
+		if (isFunction(tag)) {
+			return this.renderComponent(tag, node.attrs, node.children, context, isRoot);
+		} else {
+			return this.renderNative(tag, node, context, isRoot);
+		}
+	}
+	renderComponent(Component, props, children, context, isRoot) {
+		props = addChildrenToProps(children, props);
+
+		if (!isStatefulComponent(Component)) {
+			return this.renderNode(Component(props, context), context, isRoot);
+		}
+
+		const instance = new Component(props, context);
+		const childContext = instance.getChildContext();
+
+		if (!isNullOrUndefined(childContext)) {
+			context = Object.assign({}, context, childContext);
+		}
+		instance.context = context;
+
+		// Block setting state - we should render only once, using latest state
+		instance._pendingSetState = true;
+		return Promise.resolve(instance.componentWillMount()).then(() =>{
+			const node = instance.render();
+			instance._pendingSetState = false;
+			return this.renderNode(node, context, isRoot);
+		});
+	}
+
+	renderChildren(children, context){
+		if (isStringOrNumber(children)) {
+			return this.push(escapeText(children));
+		}
+		if (!children) {
+			return;
+		}
+
+		const childrenIsArray = isArray(children);
+		if (!childrenIsArray && !isInvalidNode(children)) {
+			return this.renderNode(children, context, false);
+		}
+		if (!childrenIsArray) {
+			throw new Error('invalid component');
+		}
+		return children.reduce((p, child)=> {
+			return p.then((insertComment)=>{
+				const isText = isStringOrNumber(child);
+				const isInvalid = isInvalidNode(child);
+
+				if (isText || isInvalid) {
+					if (insertComment === true) {
+						if (isInvalid) {
+							this.push('<!--!-->');
+						} else {
+							this.push('<!---->');
+						}
+					}
+					if (isText) {
+						this.push(escapeText(child));
+					}
+					return true;
+				} else if (isArray(child)) {
+					this.push('<!---->');
+					return Promise.resolve(this.renderChildren(child)).then(()=>{
+						this.push('<!--!-->');
+						return true;
+					});
+				} else {
+					return this.renderNode(child, context, false)
+					.then(function () {
+						return false;
+					});
+				}
+			});
+		}, Promise.resolve(false));
+	}
+
+	renderNative(tag, node, context, isRoot) {
+		const bp = node.bp;
+		const attrs = node.attrs;
+		const className = node.className;
+		const style = node.style;
+
+		const outputAttrs = renderAttributes(bp, attrs);
+		if (!isNullOrUndefined(className)) {
+			outputAttrs.push('class="' + escapeAttr(className) + '"');
+		}
+		if (!isNullOrUndefined(style)) {
+			outputAttrs.push('style="' + renderStyleToString(style) + '"');
+		}
+
+		let html = '';
+
+		if (attrs && 'dangerouslySetInnerHTML' in attrs) {
+			html = attrs[ 'dangerouslySetInnerHTML' ].__html;
+		}
+
+
+		if (isRoot) {
+			outputAttrs.push('data-infernoroot');
+		}
+		this.push(`<${tag}${outputAttrs.length > 0 ? ' ' + outputAttrs.join(' ') : ''}>`);
+		if (isVoidElement(tag)) {
+			return;
+		}
+		if (html) {
+			this.push(html);
+			this.push(`</${tag}>`);
+			return;
+		}
+		return Promise.resolve(this.renderChildren(node.children, context)).then(()=>{
+			this.push(`</${tag}>`);
+		});
+	}
+}
+
+export default function streamAsString(node) {
+	return new RenderStream(node, false);
+}
+
+export function streamAsStaticMarkup(node) {
+	return new RenderStream(node, true);
+}


### PR DESCRIPTION
Same as from here - https://github.com/trueadm/inferno/pull/303

Important notes
- I'm running componentWillMount as if it returns a promise to support fetches
- I simply copied the renderAsString tests
- I'm not rendering children in parrallel - More psuedocode below since I've thought of the problem a bit more

```javascript

// each stream is expected to be a passthrough so that they can be piped into one another
export function parrallelChildRender(parentStream, children, context){
	const locker = new QueuableLock();
	return Promise.all(children.map((child, i) =>{
		// we don't know how long a child will take to render
		// we also don't care about how long it takes for later children to prepare
		// we expect them to be done in proper order
		return Promise.resolve(prepareChildStream(child, context))
		.then(function (childStream) {
			return locker.lockWhenIndex(i).then(function () {
				return new Promise(function (res) {
					childStream.on('end', function () {
						// we don't want to have a childStream to end the mainStream
						childStream.unpipe(parentStream);
						res();
					}).pipe(parentStream);
				});
			});
		}).then(function () {
			return locker.freeLock();
		});
	}));
}

class QueuableLock {
	constructor(){
		this.taken = false;
		this.lastIndex = -1;
		this.waitingList = {};
	}
	lockWhenIndex(index) {
		return (
			this.taken === false && this.lastIndex === index - 1 ?
			Promise.resolve()
			:
			new Promise((res)=>{
				this.waitingList[ index ] = res;
			})
		).then(() =>{
			this.taken = true;
		});
	}

	freeLock(){
		this.lastIndex++;
		if (this.waitingList[ this.lastIndex + 1 ]){
			// if the next one is available, run it
			this.waitingList[ this.lastIndex + 1 ]();
		} else {
			// otherwise allow the next one to run once they are ready
			this.taken = false;
		}
	}
}

```