### PR TITLE
Allow ref callbacks on portals

### DIFF
--- a/src/DOM/mounting.js
+++ b/src/DOM/mounting.js
@@ -279,13 +279,11 @@ function mountChildren(node, children, parentDom, lifecycle, context, instance, 
 }
 
 export function mountRef(instance, value, refValue) {
-	if (!isInvalidNode(instance)) { 
-		if (isString(value)) {
-			instance.refs[value] = refValue;
-		}
-		if (isFunction(value)) {
-			value(refValue);
-		}
+	if (!isInvalidNode(instance) && isString(value)) {
+		instance.refs[value] = refValue;
+	}
+	else if (isFunction(value)) {
+		value(refValue);
 	}
 }
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -114,10 +114,12 @@ function deepScanChildrenForNode(children, node) {
 }
 
 export function getRefInstance(node, instance) {
-	const children = instance.props.children;
+	if (instance) {
+		const children = instance.props.children;
 
-	if (deepScanChildrenForNode(children, node)) {
-		return getRefInstance(node, instance._parentComponent);
+		if (deepScanChildrenForNode(children, node)) {
+			return getRefInstance(node, instance._parentComponent);
+		}
 	}
 	return instance;
 }


### PR DESCRIPTION
I'm using the portal concept in one of my components. It works like this. `render` returns `null` and then the actual rendering is done `onComponentDidMount` and `onComponentDidUpdate` to an element which was previously appended to the `body`. This is very useful for tooltips and other overlay elements.

I found that this doesn't work very well with refs because Inferno expects a valid component `instance`, which is not available during `onComponentDidUpdate`. `ref` callbacks do not need `instance`, hence this pull request.