### PR TITLE
fix Link to not preventDefault when middle clicked

### DIFF
--- a/src/router/Link.js
+++ b/src/router/Link.js
@@ -22,6 +22,10 @@ export default function Link(props, { hashbang, history }) {
 	if (!hashbang) {
 		element.setEvents({
 			onclick: function navigate(e) {
+				if (e.button !== 1) {
+					return;
+				}
+				
 				e.preventDefault();
 				const target = e.target;
 				window.history.pushState(null, target.textContent, to);


### PR DESCRIPTION
The mouse middle button click shouldn't prevent the default behavior (open in a new Tab).
Added a verification to only make the client routing if the left button is clicked.