### PR TITLE
Fix reversed renderToString/renderToStaticMarkup behavior

### DIFF
--- a/src/DOM/__tests__/hydration.spec.browser.js
+++ b/src/DOM/__tests__/hydration.spec.browser.js
@@ -1,4 +1,4 @@
-import { renderToStaticMarkup } from './../../server/renderToString';
+import renderToString from './../../server/renderToString';
 import { render } from './../../DOM/rendering';
 import { createContainerWithHTML, validateNodeTree } from '../../tools/utils';
 import createElement from './../../factories/createElement';
@@ -72,7 +72,7 @@ describe('SSR Hydration - (non-JSX)', () => {
 		// }
 	].forEach(({ node, expect1, expect2 }, i) => {
 		it(`Validate various structures #${ (i + 1) }`, () => {
-			const html = renderToStaticMarkup(node);
+			const html = renderToString(node);
 			const container = createContainerWithHTML(html);
 
 			expect(container.innerHTML).to.equal(expect1);

--- a/src/DOM/__tests__/hydration.spec.jsx.js
+++ b/src/DOM/__tests__/hydration.spec.jsx.js
@@ -1,4 +1,4 @@
-import { renderToStaticMarkup } from './../../server/renderToString';
+import renderToString from './../../server/renderToString';
 import Component from './../../component/es2015';
 import { render } from './../../DOM/rendering';
 import { createContainerWithHTML, validateNodeTree } from '../../tools/utils';
@@ -107,7 +107,7 @@ describe('SSR Hydration - (JSX)', () => {
 		}
 	].forEach(({ node, expect1, expect2 }, i) => {
 		it(`Validate various structures #${ (i + 1) }`, () => {
-			const html = renderToStaticMarkup(node);
+			const html = renderToString(node);
 			const container = createContainerWithHTML(html);
 
 			expect(container.innerHTML).to.equal(expect1);
@@ -185,7 +185,7 @@ describe('SSR Hydration - (JSX)', () => {
 		}
 	].forEach(({ node, expect1, node2, node3, expect2, expect3 }, i) => {
 		it(`Update various structures #${ (i + 1) }`, () => {
-			const html = renderToStaticMarkup(node);
+			const html = renderToString(node);
 			const container = createContainerWithHTML(html);
 
 			expect(container.innerHTML).to.equal(expect1);

--- a/src/server/__tests__/creation.spec.browser.js
+++ b/src/server/__tests__/creation.spec.browser.js
@@ -1,4 +1,4 @@
-import renderToString from './../renderToString';
+import {renderToStaticMarkup} from './../renderToString';
 import Component from './../../component/es2015';
 import createElement from './../../factories/createElement';
 
@@ -81,7 +81,7 @@ describe('SSR Creation - (non-JSX)', () => {
 		it(test.description, () => {
 			const container = document.createElement('div');
 			const vDom = test.template('foo');
-			const output = renderToString(vDom, true);
+			const output = renderToStaticMarkup(vDom, true);
 
 			document.body.appendChild(container);
 			container.innerHTML = output;

--- a/src/server/renderToString.ts
+++ b/src/server/renderToString.ts
@@ -156,9 +156,9 @@ function renderInputToString(input, context, isRoot) {
 }
 
 export default function renderToString(input) {
-	return renderInputToString(input, null, false);
+	return renderInputToString(input, null, true);
 }
 
 export function renderToStaticMarkup(input) {
-	return renderInputToString(input, null, true);
+	return renderInputToString(input, null, false);
 }


### PR DESCRIPTION
In React, [`renderToStaticMarkup`](https://facebook.github.io/react/docs/top-level-api.html#reactdomserver.rendertostaticmarkup) yields plain HTML (without react-ids, etc) whereas [`renderToString`](https://facebook.github.io/react/docs/top-level-api.html#reactdomserver.rendertostring) produces markup meant for use in conjunction client-side rendering/hydration. Inferno currently has the reverse.

This PR reverses the behavior of these methods in inferno-server to match React.