### PR TITLE
Make use of Github Contribution Tools

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Got a question or need help?
 If you're having trouble getting Inferno to do what you want, there are a couple of places to get help before submitting an issue:
 
 * [Stack Overflow questions tagged infernojs](http://stackoverflow.com/questions/tagged/infernojs)
-* [The Inferno Documentation](http://docs.infernojs.org)
+* [The Inferno Documentation](http://docs.infernojs.org) (Coming soon.)
 
 Of course, if you've encountered a bug, then the best course of action is to raise an issue (if no-one else has!).
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+*Before* submitting an issue please:
+- Check that you are using the latest version of Inferno. Either using our [CDN @ Master](http://cdn.infernojs.org/latest/inferno.js) or by checking the tags on [NPM](http://www.npmjs.com/package/inferno).
+- Check that the bug has not been fixed in the latest development version. Use our [CDN @ Edge](http://cdn.infernojs.org/edge/inferno.js).
+- Check that the issue has not been brought up before on [Github issues](http://www.github.com/trueadm/inferno/issues).
+
+**If you can, please distill your problem down and include a JSFiddle example for illustration.**
+
+---
+
+## Issue Template
+
+**Observed Behaviour**
+
+Inferno is...
+
+**Expected Current Behaviour**
+
+Inferno should... 
+
+**Inferno Metadata**
+
+macOS / Windowx / Linux
+Safari / Chrome / Firefox / ... 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+ *Before* submitting a PR please:
+ - Make sure you have based your branch off the [dev branch](https://github.com/infernojs/inferno/tree/dev).
+ - Submit your PR against the [dev branch](https://github.com/infernojs/inferno/tree/dev).
+ - Run `npm run build` and check that the build succeeds.
+ - Ensure that the PR hasn't been submitted before.
+
+---
+
+## PR Template
+
+**Objective**
+
+This PR...
+
+**Closes Issue**
+
+It closes Issue #...


### PR DESCRIPTION
This moves the contributing documentation into the .github folder to make use of the issue & PR templates.

Both are based off the comments in CONTRIBUTING.md and React's templates. I've tried to make them self explanatory with some simple comments designed to make it easier to track issue assignment and closure. 