### PR TITLE
Fix ternary render hydration

### DIFF
--- a/src/DOM/hydration.ts
+++ b/src/DOM/hydration.ts
@@ -18,7 +18,8 @@ import {
 import {
 	mountVText,
 	mountStatelessComponentCallbacks,
-	mountStatefulComponentCallbacks
+	mountStatefulComponentCallbacks,
+	mountChildren
 } from './mounting';
 import {
 	isVPlaceholder,
@@ -184,7 +185,7 @@ function hydrateChildrenWithUnknownType(children, dom, lifecycle, context) {
 	}
 }
 
-function hydrateChildren(childrenType, children, dom, lifecycle, context) {
+function hydrateChildren(childrenType, children, dom, lifecycle, context, isSVG = false) {
 	if (isNodeChildrenType(childrenType)) {
 		hydrate(children, dom.firstChild, lifecycle, context);
 	} else if (isKeyedListChildrenType(childrenType) || isNonKeyedListChildrenType(childrenType)) {
@@ -278,10 +279,14 @@ function hydrateVFragment(vFragment, currentDom, lifecycle, context) {
 	parentDom.insertBefore(pointer, currentDom);
 }
 
-function hydrateOptVElementValue(optVElement, valueType, value, descriptor, dom, lifecycle, context) {
+function hydrateOptVElementValue(optVElement, valueType, value, descriptor, dom, lifecycle, context, isSVG = false) {
 	switch (valueType) {
 		case ValueTypes.CHILDREN:
-			hydrateChildren(descriptor, value, dom, lifecycle, context);
+			if (value === null) {
+				mountChildren(descriptor, value, dom, lifecycle, context, isSVG, false);
+			} else {
+				hydrateChildren(descriptor, value, dom, lifecycle, context, isSVG);
+			}
 			break;
 		case ValueTypes.PROP_SPREAD:
 			debugger;
@@ -311,10 +316,10 @@ function hydrate(input, dom, lifecycle, context) {
 		hydrateVComponent(input, dom, lifecycle, context);
 	} else if (isVElement(input)) {
 		hydrateVElement(input, dom, lifecycle, context);
-	} else if (isVFragment(input)) {
-		hydrateVFragment(input, dom, lifecycle, context);
 	} else if (isVText(input)) {
 		hydrateVText(input, dom);
+	} else if (isVFragment(input)) {
+		hydrateVFragment(input, dom, lifecycle, context);
 	} else if (isVPlaceholder(input)) {
 		debugger;
 	} else {

--- a/src/DOM/mounting.ts
+++ b/src/DOM/mounting.ts
@@ -232,7 +232,7 @@ function mountOptVElementValue(optVElement, valueType, value, descriptor, dom, l
 	}
 }
 
-function mountChildren(childrenType, children, dom, lifecycle, context, isSVG, shallowUnmount) {
+export function mountChildren(childrenType, children, dom, lifecycle, context, isSVG, shallowUnmount) {
 	if (isTextChildrenType(childrenType)) {
 		setTextContent(dom, children);
 	} else if (isNodeChildrenType(childrenType)) {


### PR DESCRIPTION
I'm not sure if this is the way to go but this fixes the following for me when hydrating:

````
return <div className="column">
                    {errorMsg && <Error text={errorMsg}/>}
           </div>
```

Previously you would get an error `childNodes of null...`