### PR TITLE
Fixed SSR hydration case

### DIFF
--- a/src/DOM/__tests__/hydration.spec.jsx.js
+++ b/src/DOM/__tests__/hydration.spec.jsx.js
@@ -46,6 +46,11 @@ describe('SSR Hydration - (JSX)', () => {
 			expect2: '<div><span>Hello world</span></div>'
 		},
 		{
+			node: <div><p>Hello world<sup><a>Foo</a></sup></p></div>,
+			expect1: '<div data-infernoroot=""><p>Hello world<sup><a>Foo</a></sup></p></div>',
+			expect2: '<div><p>Hello world<sup><a>Foo</a></sup></p></div>'
+		},
+		{
 			node: <div>{ <span>Hello world</span> }</div>,
 			expect1: '<div data-infernoroot=""><span>Hello world</span></div>',
 			expect2: '<div><span>Hello world</span></div>'

--- a/src/DOM/hydration.ts
+++ b/src/DOM/hydration.ts
@@ -203,7 +203,7 @@ function hydrateChildren(childrenType, children, dom, lifecycle, context, isSVG 
 function hydrateStaticVElement(node, dom) {
 	const children = node.children;
 
-	if (!isNull(children)) {
+	if (!isNull(children) && !isNullOrUndef(dom)) {
 		if (!isStringOrNumber(children) && !isInvalid(children)) {
 			let childNode = dom.firstChild;
 


### PR DESCRIPTION
EDIT: I have included a simple fix for this. There may be a better way to do this (I'm still new to the codebase) but tests now pass.

This PR adds a failing test that demonstrates the problem below:

Upon hydrating the following DOM
```jsx
<div>
  <p>Hello world<sup><a>Foo</a></sup></p>
</div>
```
an uncaught error is thrown: `TypeError: Cannot read property 'firstChild' of undefined`

The source of the error is [this line in `hydrateStaticVElement`](https://github.com/trueadm/inferno/blob/6bf2580236aa1062f834d31ef8ae70a2282bde29/src/DOM/hydration.ts#L208)