### PR TITLE
Allow passing children through props

### DIFF
--- a/src/factories/__tests__/createElement.spec.browser.js
+++ b/src/factories/__tests__/createElement.spec.browser.js
@@ -60,4 +60,33 @@ describe('CreateElement (non-JSX)', () => {
 
 		expect(triggered).to.equal(true);
 	});
+
+	it('Should allow passing childs through "children" property (native component)', () => {
+		const app = () => {
+			return createElement('div', null,
+				createElement('button', {
+					type: 'button',
+					children: ['Do a thing']
+				})
+			);
+		};
+
+		render(app(), container);
+		expect(container.innerHTML).to.equal('<div><button type="button">Do a thing</button></div>');
+	});
+
+	it('Should allow passing childs through "children" property (custom component)', () => {
+		const Button = props => createElement('button', props);
+		const app = () => {
+			return createElement('div', null,
+				createElement(Button, {
+					type: 'button',
+					children: ['Do a thing']
+				})
+			);
+		};
+
+		render(app(), container);
+		expect(container.innerHTML).to.equal('<div><button type="button">Do a thing</button></div>');
+	});
 });

--- a/src/factories/createElement.ts
+++ b/src/factories/createElement.ts
@@ -34,7 +34,7 @@ export default function createElement(name: string | Function, props?: any, ..._
 		if (_children.length === 1) {
 			children = _children[0];
 		} else if (_children.length === 0) {
-			children = null;
+			children = undefined;
 		}
 	}
 	if (isString(name)) {
@@ -44,8 +44,8 @@ export default function createElement(name: string | Function, props?: any, ..._
 			if (prop === 'key') {
 				vNode.key = props.key;
 				delete props.key;
-			} else if (prop === 'children') {
-				vNode.children = children;
+			} else if (prop === 'children' && isUndefined(children)) {
+				vNode.children = props.children; // always favour children args, default to props
 			} else if (prop === 'ref') {
 				vNode.ref = props.ref; // TODO: Verify it works - tests
 			} else if (isAttrAnEvent(prop)) {


### PR DESCRIPTION
This mimics React behaviour and allows to pass children as props. Useful in wrapper components, those you can find in react-bootstrap for example.