### PR TITLE
Failing test case with computed class name attribute and another attribute

### DIFF
--- a/src/DOM/__tests__/hydration.spec.jsx.js
+++ b/src/DOM/__tests__/hydration.spec.jsx.js
@@ -73,6 +73,11 @@ describe('SSR Hydration - (JSX)', () => {
 			expect2: '<div>Hello world</div>'
 		},
 		{
+			node: <div><svg className={(() => 'foo')()} viewBox="0 0 64 64"></svg></div>,
+			expect1: '<div data-infernoroot=""><svg class="foo" viewBox="0 0 64 64"}></svg></div>',
+			expect2: '<div><svg class="foo" viewBox="0 0 64 64"}></svg></div>'
+		},
+		{
 			node: <Comp4><h1>Hello world</h1><p><em>Foo</em></p><p>Woot</p><p><em>Bar</em></p></Comp4>,
 			expect1: '<section data-infernoroot=""><h1>Hello world</h1><p><em>Foo</em></p><p>Woot</p><p><em>Bar</em></p></section>',
 			expect2: '<section><h1>Hello world</h1><p><em>Foo</em></p><p>Woot</p><p><em>Bar</em></p></section>'


### PR DESCRIPTION
This PR adds a failing test case with a computed class name attribute and another attribute. Either attribute on its own works, but when both attributes exist, the computed class name is lost.

Source:
```jsx
<svg className={(() => 'foo')()} viewBox="0 0 64 64"></svg>
```
Expected:
```html
<svg class="foo" viewBox="0 0 64 64"></svg>
```
Actual:
```html
<svg viewBox="0 0 64 64"></svg>
```