### PR TITLE
Router History

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "packages:purge": "rimraf node_modules",
     "packages:reinstall": "npm run packages:purge && npm install",
     "prepublish": "npm run build",
-    "prepush": "npm run eslint:source && npm lint:source && npm test",
+    "prepush": "npm run eslint:source && npm run lint:source && npm test",
     "server:cov": "cross-env nyc mocha --opts config/mocha.opts",
     "server:cov:publish": "npm run server:cov && coveralls < coverage/lcov.info && rimraf coverage",
     "test": "npm run test:browser && npm run test:server",

--- a/src/router/Router.ts
+++ b/src/router/Router.ts
@@ -1,6 +1,6 @@
 import Component from '../component/es2015';
-import { isArray, toArray } from '../shared';
-import { isEmpty, matchPath, pathRankSort } from './utils';
+import { toArray } from '../shared';
+import { getRoutes } from './utils';
 
 export interface IRouterProps {
 	url: string;
@@ -10,47 +10,6 @@ export interface IRouterProps {
 	component?: Component<any, any>;
 }
 
-export function getRoutes(routing, currentURL: string) {
-	let params = {};
-
-	function grabRoutes(_routes, url: string, lastPath: string) {
-		if (!_routes) {
-			return _routes;
-		}
-
-		const routes = toArray(_routes);
-		routes.sort(pathRankSort);
-
-		for (let i = 0; i < routes.length; i++) {
-			const route = routes[i];
-
-			if (isArray(route)) {
-				return grabRoutes(route, url, lastPath);
-			}
-
-			const { children, path = '/' } = route.props;
-			const fullPath = (lastPath + path).replace('//', '/');
-			const isLast = isEmpty(children);
-
-			if (children) {
-				route.props.children = grabRoutes(children, url, fullPath);
-			}
-
-			const match = matchPath(isLast, fullPath, url.replace('//', '/'));
-			if (match) {
-				route.props.params = Object.assign(params, match.params);
-				if (route.instance) {
-					return route.type(route.instance.props, route.instance.context);
-				} else {
-					return route;
-				}
-			}
-		}
-	}
-
-	return grabRoutes(routing, currentURL, '');
-}
-
 export default class Router extends Component<IRouterProps, any> {
 	_didRoute: boolean;
 	router: any;
@@ -58,6 +17,9 @@ export default class Router extends Component<IRouterProps, any> {
 
 	constructor(props?: any, context?: any) {
 		super(props, context);
+		if (!props.history && !props.matched) {
+			throw new TypeError('Inferno: Error "inferno-router" requires a history prop passed, or a matched Route');
+		}
 		this._didRoute = false;
 		this.router = props.history;
 		this.state = {

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -1,6 +1,6 @@
 import pathToRegExp0 from 'path-to-regexp';
 import pathToRegExp1 = require('path-to-regexp');
-import { isArray } from '../shared';
+import { isArray, toArray } from '../shared';
 
 const pathToRegExp: any = pathToRegExp0 || pathToRegExp1;
 const cache: Map<string, IMatchRegex> = new Map();
@@ -8,6 +8,47 @@ const emptyObject: Object = {};
 
 function decode(val: any): any {
 	return typeof val !== 'string' ? val : decodeURIComponent(val);
+}
+
+export function getRoutes(routing, currentURL: string) {
+	let params = {};
+
+	function grabRoutes(_routes, url: string, lastPath: string) {
+		if (!_routes) {
+			return _routes;
+		}
+
+		const routes = toArray(_routes);
+		routes.sort(pathRankSort);
+
+		for (let i = 0; i < routes.length; i++) {
+			const route = routes[i];
+
+			if (isArray(route)) {
+				return grabRoutes(route, url, lastPath);
+			}
+
+			const { children, path = '/' } = route.props;
+			const fullPath = (lastPath + path).replace('//', '/');
+			const isLast = isEmpty(children);
+
+			if (children) {
+				route.props.children = grabRoutes(children, url, fullPath);
+			}
+
+			const match = matchPath(isLast, fullPath, url.replace('//', '/'));
+			if (match) {
+				route.props.params = Object.assign(params, match.params);
+				if (route.instance) {
+					return route.type(route.instance.props, route.instance.context);
+				} else {
+					return route;
+				}
+			}
+		}
+	}
+
+	return grabRoutes(routing, currentURL, '');
 }
 
 export function isEmpty(children): boolean {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,11 @@
 		"strictNullChecks": false,
 		"removeComments": false
 	},
+	"include": [
+		"src/**/*"
+  ],
 	"exclude": [
-		"node_modules"
+		"node_modules",
+		"src/**/*.spec*"
 	]
 }


### PR DESCRIPTION
Adds a Error if the `history` prop is not set on a Router and there is no matched Route. 