### PR TITLE
Fixed a typo: documetBody -> documentBody

### DIFF
--- a/src/DOM/rendering.ts
+++ b/src/DOM/rendering.ts
@@ -62,10 +62,10 @@ function removeRoot(root): void {
 	}
 }
 
-const documetBody = isBrowser ? document.body : null;
+const documentBody = isBrowser ? document.body : null;
 
 export function render(input: InfernoInput, parentDom?: Node | SVGAElement) {
-	if (documetBody === parentDom) {
+	if (documentBody === parentDom) {
 		if (process.env.NODE_ENV !== 'production') {
 			throwError('you cannot render() to the "document.body". Use an empty element as a container instead.');
 		}


### PR DESCRIPTION
Accidentally stumbled upon it in a source code. Might help someone when searching.