### PR TITLE
Omit quotes around valueless attributes

### DIFF
--- a/src/server/__tests__/creation.spec.tsx
+++ b/src/server/__tests__/creation.spec.tsx
@@ -27,6 +27,10 @@ describe('SSR Creation (JSX)', () => {
 		template: () => <div>{ null }<span>emptyValue: { null }</span></div>,
 		result: '<div><span>emptyValue: </span></div>'
 	}, {
+		description: 'should render a component with valueless attribute',
+		template: () => <script src="foo" async></script>,
+		result: '<script src="foo" async></script>'
+	}, {
 		description: 'should render a stateless component with text',
 		template: () => <div>Hello world, { '1' }2{ '3' }</div>,
 		result: '<div>Hello world, <!---->1<!---->2<!---->3</div>'

--- a/src/server/renderToString.ts
+++ b/src/server/renderToString.ts
@@ -81,7 +81,7 @@ function renderVNodeToString(vNode, context, firstChild) {
 					if (isStringOrNumber(value)) {
 						renderedString += ` ${ prop }="${ escapeText(value) }"`;
 					} else if (isTrue(value)) {
-						renderedString += ` "${ prop }"`;
+						renderedString += ` ${ prop }`;
 					}
 				}
 			}


### PR DESCRIPTION
Before:
```html
<script src="foo" "async"></script>
```

After:
```html
<script src="foo" async></script>
```

I think the former is invalid HTML.
