### PR TITLE
Update user infernojs -> trueadm for dev branch links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Pull requests
 
 **Pull requests against the master branch will not be merged!**
 
-All pull requests are welcome. You should create a new branch, based on the [dev branch](https://github.com/infernojs/inferno/tree/dev), and submit the PR against the dev branch.
+All pull requests are welcome. You should create a new branch, based on the [dev branch](https://github.com/trueadm/inferno/tree/dev), and submit the PR against the dev branch.
 
 *Caveat for what follows: If in doubt, submit the request - a PR that needs tweaking is infinitely more valuable than a request that wasn't made because you were worrying about meeting these requirements.*
 


### PR DESCRIPTION
**Objective**

This PR updates `infernojs` user to `trueadm` when referring to the `dev` branch for contributors.

**Closes Issue**

No related issue

---

Very very minor, but I ran across this while looking for some way that I could contribute!