### PR TITLE
Fix unhandled promise rejection in test

### DIFF
--- a/src/DOM/__tests__/functional.spec.tsx
+++ b/src/DOM/__tests__/functional.spec.tsx
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { createRenderer } from './../rendering';
 import * as Inferno from '../../testUtils/inferno';
-import {map, scan} from 'most';
-import { hold } from 'most-subject';
+import {map, scan, reduce} from 'most';
+import { hold, sync } from 'most-subject';
 import {curry} from 'lodash/fp';
 import Type from 'union-type';
 Inferno; // suppress ts 'never used' error
@@ -23,7 +23,7 @@ describe('Functional methods (JSX)', () => {
 			Decrement: _ => model - 1
 		}, action);
 
-		const actions$ = hold();
+		const actions$ = hold(1, sync());
 
 		const emitAction = action => actions$.next(action);
 		const emitDecrement = _ => emitAction(Action.Decrement());
@@ -54,7 +54,7 @@ describe('Functional methods (JSX)', () => {
 
 		const renderer = createRenderer();
 
-		const runApp = () => scan(renderer, container, vNodes$).drain();
+		const runApp = () => reduce(renderer, container, vNodes$);
 
 		runApp();
 		setTimeout(() => {

--- a/src/inferno.d.ts
+++ b/src/inferno.d.ts
@@ -101,11 +101,13 @@ declare module 'sinon' {
 
 declare module 'most' {
 	export function map(f?: any, stream?: any): any;
+	export function reduce(f?: any, intitial?: any, stream?: any): any;
 	export function scan(f?: any, initial?: any, stream?: any): any;
 }
 
 declare module 'most-subject' {
 	export function hold(bufferSize?: number, subject?: any): any
+	export function sync(): void;
 }
 
 declare module 'lodash/fp' {


### PR DESCRIPTION
This PR fixes an unhandled promise rejection warnings in `functional.spec.tsx` where `most-subject` is incorrectly used. These kind of warnings will throw an exception in the future starting with node 8.

Background: https://github.com/cujojs/most/issues/362#issuecomment-264633146
