### PR TITLE
Fixed test issue with decimal separator

### DIFF
--- a/src/DOM/__tests__/styles.spec.tsx
+++ b/src/DOM/__tests__/styles.spec.tsx
@@ -25,7 +25,7 @@ describe('CSS style properties (JSX)', () => {
 
 		render(<div style={ styles }/>, container);
 		expect(container.firstChild.style.fontFamily).to.equal('Arial');
-		expect(container.firstChild.style.lineHeight).to.equal('1.2');
+		expect(container.firstChild.style.lineHeight).to.equal(1.2.toLocaleString());
 
 		render(<div />, container);
 		expect(container.firstChild.style.fontFamily).to.equal('');


### PR DESCRIPTION
On some locales decimal separator is comma, which leads to a failed test (returns `1,2` instead of expected `1.2`). This PR fixes it.



