### PR TITLE
Makes render compliant with React's version

### DIFF
--- a/src/DOM/__tests__/rendering.spec.ts
+++ b/src/DOM/__tests__/rendering.spec.ts
@@ -41,4 +41,10 @@ describe('rendering routine', () => {
 		expect(container.innerHTML).to.eql('<div><div>123</div></div>');
 	});
 
+	it('Should return Inferno instance of rendered input', () => {
+		const input = createVNode(VNodeFlags.Element, 'div', null, '289', null, null, true);
+
+		const result = render(input, container);
+		expect(result).to.eql(input);
+	})
 });

--- a/src/DOM/rendering.ts
+++ b/src/DOM/rendering.ts
@@ -122,6 +122,7 @@ export function render(input: InfernoInput, parentDom?: Node | SVGAElement) {
 	if (devToolsStatus.connected) {
 		sendRoots(window);
 	}
+	return input;
 }
 
 export function createRenderer() {


### PR DESCRIPTION
**Objective**

This PR makes render compliant with React's version. ReactDOM.render return signature is
```
/**
* ...
* @return {ReactComponent} Component instance rendered in `container`.
*/
```
We should support it for `inferno-compat` (for example, this behaviour is used in `react-virtualized` tests).

