### PR TITLE
cross-browser innerhtml fixes

### DIFF
--- a/src/DOM/__tests__/elements.spec.tsx
+++ b/src/DOM/__tests__/elements.spec.tsx
@@ -754,7 +754,7 @@ describe('Elements (JSX)', () => {
 		render((
 			<div { ...foo } { ...bar } />
 		), container);
-		expect(container.innerHTML).to.equal('<div class="lol" id="test">Hello world!</div>');
+		expect(container.innerHTML).to.equal(innerHTML('<div class="lol" id="test">Hello world!</div>'));
 	});
 
 	it('mixing JSX with non-JSX', () => {

--- a/src/DOM/__tests__/elements.spec.tsx
+++ b/src/DOM/__tests__/elements.spec.tsx
@@ -3,8 +3,8 @@ import * as Inferno from '../../testUtils/inferno';
 import { assert, spy } from 'sinon';
 
 import createElement from './../../factories/createElement';
-import { expect } from 'chai';
 import { innerHTML } from '../../tools/utils';
+import { expect } from 'chai';
 import { render } from './../rendering';
 
 Inferno; // suppress ts 'never used' error

--- a/src/DOM/__tests__/update.spec.tsx
+++ b/src/DOM/__tests__/update.spec.tsx
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { assert, spy } from 'sinon';
 import { render } from '../rendering';
 import Component from '../../component/es2015';
+import { innerHTML } from '../../tools/utils';
 import * as Inferno from 'inferno';
 Inferno; // suppress ts 'never used' error
 
@@ -557,7 +558,7 @@ describe('Stateful Component updates', () => {
 		}
 
 		render(<Tester/>, container);
-		expect(container.innerHTML).to.eql('<form><input type="text" id="inputId"></form>');
+		expect(container.innerHTML).to.eql(innerHTML('<form><input type="text" id="inputId"></form>'));
 		const input = container.querySelector('#inputId');
 		expect(assert.notCalled(submitSpy));
 		input.focus();

--- a/src/component/__tests__/components.spec.tsx
+++ b/src/component/__tests__/components.spec.tsx
@@ -2040,7 +2040,7 @@ describe('Components (JSX)', () => {
 			render(
 				<Input />, container
 			);
-			expect(container.innerHTML).to.equal('<input class="foo" id="test">');
+			expect(container.innerHTML).to.equal(innerHTML('<input class="foo" id="test">'));
 		});
 	});
 
@@ -2246,20 +2246,20 @@ describe('Components (JSX)', () => {
 
 		it('should mount component with defaultProps', () => {
 			render(<Comp1 c='C'/>, container);
-			expect(container.innerHTML).to.equal('<div class="A" id="B">Hello C!</div>');
+			expect(container.innerHTML).to.equal(innerHTML('<div class="A" id="B">Hello C!</div>'));
 		});
 
 		it('should patch component with defaultProps', () => {
 			render(<Comp1 c='C'/>, container);
 			render(<Comp1 c='C2'/>, container);
-			expect(container.innerHTML).to.equal('<div class="A" id="B">Hello C2!</div>');
+			expect(container.innerHTML).to.equal(innerHTML('<div class="A" id="B">Hello C2!</div>'));
 		});
 		it('should patch component with defaultProps #2', () => {
 			render(<Comp1 c='C'/>, container);
 			render(<Comp2 c='C1'/>, container);
-			expect(container.innerHTML).to.equal('<div class="aye" id="bee">Hello C1!</div>');
+			expect(container.innerHTML).to.equal(innerHTML('<div class="aye" id="bee">Hello C1!</div>'));
 			render(<Comp1 c='C2'/>, container);
-			expect(container.innerHTML).to.equal('<div class="A" id="B">Hello C2!</div>');
+			expect(container.innerHTML).to.equal(innerHTML('<div class="A" id="B">Hello C2!</div>'));
 		});
 	});
 

--- a/src/component/__tests__/components.spec.tsx
+++ b/src/component/__tests__/components.spec.tsx
@@ -3,8 +3,8 @@ import { assert, spy } from 'sinon';
 import Component from 'inferno-component';
 import * as Inferno from 'inferno';
 import createElement from 'inferno-create-element';
-import { expect } from 'chai';
 import { innerHTML } from '../../tools/utils';
+import { expect } from 'chai';
 
 const render = Inferno.render;
 

--- a/src/factories/__tests__/hyperscript.spec.browser.ts
+++ b/src/factories/__tests__/hyperscript.spec.browser.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { render } from '../../DOM/rendering';
 import h from '../hyperscript';
-
+import { innerHTML } from '../../tools/utils'
 describe('HyperScript (non-JSX)', () => {
 	let container;
 
@@ -80,7 +80,7 @@ describe('HyperScript (non-JSX)', () => {
 			h(ComponentHooks),
 			container
 		);
-		expect(container.innerHTML).to.equal('<div class="test myClass" id="myId">Hello world!</div>');
+		expect(container.innerHTML).to.equal(innerHTML('<div class="test myClass" id="myId">Hello world!</div>'));
 	});
 
 	it('Should handle tag with no name', () => {

--- a/src/router/__tests__/components.spec.tsx
+++ b/src/router/__tests__/components.spec.tsx
@@ -5,6 +5,7 @@ import Route from '../Route';
 import Router from '../Router';
 import IndexLink from '../IndexLink';
 import Link from '../Link';
+import { innerHTML } from '../../tools/utils';
 import createMemoryHistory from 'history/createMemoryHistory';
 import {
 	expect,
@@ -76,7 +77,7 @@ describe('Router components (jsx)', () => {
 				<IndexLink activeClassName="linkActiveClass" className="linkClass" activeStyle={{ fontWeight: 'bold' }}>IndexLink</IndexLink>
 			), container);
 
-			expect(container.innerHTML).to.equal('<a href="/" class="linkClass linkActiveClass" style="font-weight: bold;">IndexLink</a>');
+			expect(container.innerHTML).to.equal(innerHTML('<a href="/" class="linkClass linkActiveClass" style="font-weight: bold;">IndexLink</a>'));
 		});
 
 		it('should route on click', (done) => {
@@ -85,7 +86,7 @@ describe('Router components (jsx)', () => {
 				<Route path={'/test'} component={ () => <TestComponent/> }/>
 			</Router>, container);
 
-			expect(container.innerHTML).to.equal('<div><a href="/test">Link</a><a href="/">IndexLink</a></div>');
+			expect(container.innerHTML).to.equal(innerHTML('<div><a href="/test">Link</a><a href="/">IndexLink</a></div>'));
 
 			const link = container.querySelector('a[href="/"]');
 			clickOnLink(link);


### PR DESCRIPTION
Fixes some tests that were failing when running browsers other than google chrome.

Some tests were failing because where chrome would render: `<input class="foo" id="test">`
Firefox / safari / edge might render: `<input id="test" class="foo">`

This PR uses our innerHTML utility to fix those tests and ensure that the strings we are comparing rendered components to correspond to what they would be in the browser running the tests.

This only addresses compatibility issues that have to do with comparing HTML strings.
