### PR TITLE
Avoid TypeError by setting props to empty object

### DIFF
--- a/src/DOM/hydration.ts
+++ b/src/DOM/hydration.ts
@@ -4,8 +4,8 @@ import {
 	createStatelessComponentInput,
 	replaceChild,
 } from './utils';
+import { EMPTY_OBJ } from 'inferno';
 import {
-	EMPTY_OBJ,
 	isArray,
 	isInvalid,
 	isNull,

--- a/src/DOM/hydration.ts
+++ b/src/DOM/hydration.ts
@@ -5,6 +5,7 @@ import {
 	replaceChild,
 } from './utils';
 import {
+	EMPTY_OBJ,
 	isArray,
 	isInvalid,
 	isNull,
@@ -58,7 +59,7 @@ export function normaliseChildNodes(dom) {
 
 function hydrateComponent(vNode, dom, lifecycle, context, isSVG, isClass) {
 	const type = vNode.type;
-	const props = vNode.props || {};
+	const props = vNode.props || EMPTY_OBJ;
 	const ref = vNode.ref;
 
 	vNode.dom = dom;
@@ -76,7 +77,7 @@ function hydrateComponent(vNode, dom, lifecycle, context, isSVG, isClass) {
 		const fastUnmount = lifecycle.fastUnmount;
 
 		// we store the fastUnmount value, but we set it back to true on the lifecycle
-		// we do this so we can determine if the component render has a fastUnmount or not		
+		// we do this so we can determine if the component render has a fastUnmount or not
 		lifecycle.fastUnmount = true;
 		instance._vComponent = vNode;
 		instance._vNode = vNode;

--- a/src/DOM/mounting.ts
+++ b/src/DOM/mounting.ts
@@ -1,5 +1,5 @@
+import { EMPTY_OBJ } from 'inferno';
 import {
-	EMPTY_OBJ,
 	isArray,
 	isFunction,
 	isInvalid,

--- a/src/server/renderToString.ts
+++ b/src/server/renderToString.ts
@@ -6,8 +6,8 @@ import {
 import {
 	copyPropsTo
 } from '../DOM/utils';
+import { EMPTY_OBJ } from 'inferno';
 import {
-	EMPTY_OBJ,
 	isArray,
 	isInvalid,
 	isNull,

--- a/src/server/renderToString.ts
+++ b/src/server/renderToString.ts
@@ -7,6 +7,7 @@ import {
 	copyPropsTo
 } from '../DOM/utils';
 import {
+	EMPTY_OBJ,
 	isArray,
 	isInvalid,
 	isNull,
@@ -44,7 +45,7 @@ function renderStylesToString(styles) {
 function renderVNodeToString(vNode, context, firstChild) {
 	const flags = vNode.flags;
 	const type = vNode.type;
-	let props = vNode.props;
+	const props = vNode.props || EMPTY_OBJ;
 	const children = vNode.children;
 
 	if (flags & VNodeFlags.Component) {


### PR DESCRIPTION
This PR closes an issue with a TypeError when rendering components on the server via InfernoServer.renderToString.

I'm not sure about the proposed change from "let props =" to "const props =", though.