### PR TITLE
Add skipped test on children props not bubbling to parent

### DIFF
--- a/src/component/__tests__/components.spec.tsx
+++ b/src/component/__tests__/components.spec.tsx
@@ -2255,6 +2255,12 @@ describe('Components (JSX)', () => {
 			expect(innerHTML(container.innerHTML)).to.equal(innerHTML('<div class="A" id="B">Hello C!</div>'));
 		});
 
+		it.skip('should mount child component with its defaultProps', () => {
+			const Parent = props => <div>{props.children.props.a}</div>;
+			render(<Parent><Comp1 c='C' /></Parent>, container);
+			expect(innerHTML(container.innerHTML)).to.equal(innerHTML('<div>A</div>'));
+		});
+
 		it('should patch component with defaultProps', () => {
 			render(<Comp1 c='C'/>, container);
 			render(<Comp1 c='C2'/>, container);


### PR DESCRIPTION
@trueadm Maybe you don't want to bubble up children props, but this is something `inferno-compat` should support. In that case this skipped test is a no-go but the issue still would need to be fixed in `inferno-compat`