### PR TITLE
Check for undefined going to Children.map => Children.toArray

### DIFF
--- a/packages/inferno-compat/src/index.js
+++ b/packages/inferno-compat/src/index.js
@@ -35,8 +35,9 @@ const Children = {
 		return children[0];
 	},
 	toArray(children) {
-		const invalid = children === null || children === undefined
-		return invalid ? [] : Array.isArray && Array.isArray(children) ? children : ARR.concat(children);
+		return (children === null || children === undefined)
+			? []
+			: Array.isArray && Array.isArray(children) ? children : ARR.concat(children);
 	}
 };
 

--- a/packages/inferno-compat/src/index.js
+++ b/packages/inferno-compat/src/index.js
@@ -35,7 +35,8 @@ const Children = {
 		return children[0];
 	},
 	toArray(children) {
-		return Array.isArray && Array.isArray(children) ? children : ARR.concat(children);
+		const invalid = children === null || children === undefined
+		return invalid ? [] : Array.isArray && Array.isArray(children) ? children : ARR.concat(children);
 	}
 };
 


### PR DESCRIPTION
I was trying this out and I found a bug.
If you have no children and call map on the children object then Children.toArray is called with undefined and it returns [undefined] which is a 'mappable' object and the world goes BOOOM because you're trying to access something of undefined. I guess you got the idea...
