### PR TITLE
Add checks for null and undefined on Inferno-Compat(React.Children)

### DIFF
--- a/packages/inferno-compat/src/index.js
+++ b/packages/inferno-compat/src/index.js
@@ -12,19 +12,21 @@ function unmountComponentAtNode(container) {
 	return true;
 }
 
+function isNullOrUndef(children) {
+	return children === null || children === undefined;
+}
+
 const ARR = [];
 
 const Children = {
 	map(children, fn, ctx) {
-		if (children === undefined) { return undefined; }
-		if (children === null) { return null; }
+		if (isNullOrUndef(children)) {return children;}
 		children = Children.toArray(children);
 		if (ctx && ctx !== children) {fn = fn.bind(ctx);}
 		return children.map(fn);
 	},
 	forEach(children, fn, ctx) {
-		if (children === undefined) { return undefined; }
-		if (children === null) { return null; }
+		if (isNullOrUndef(children)) {return children;}
 		children = Children.toArray(children);
 		if (ctx && ctx !== children) {fn = fn.bind(ctx);}
 		children.forEach(fn);
@@ -39,7 +41,7 @@ const Children = {
 		return children[0];
 	},
 	toArray(children) {
-		if (children === undefined || children === null) { return []; }
+		if (isNullOrUndef(children)) {return [];}
 		return Array.isArray && Array.isArray(children) ? children : ARR.concat(children);
 	}
 };

--- a/packages/inferno-compat/src/index.js
+++ b/packages/inferno-compat/src/index.js
@@ -16,11 +16,15 @@ const ARR = [];
 
 const Children = {
 	map(children, fn, ctx) {
+		if (children === undefined) { return undefined; }
+		if (children === null) { return null; }
 		children = Children.toArray(children);
 		if (ctx && ctx !== children) {fn = fn.bind(ctx);}
 		return children.map(fn);
 	},
 	forEach(children, fn, ctx) {
+		if (children === undefined) { return undefined; }
+		if (children === null) { return null; }
 		children = Children.toArray(children);
 		if (ctx && ctx !== children) {fn = fn.bind(ctx);}
 		children.forEach(fn);
@@ -35,6 +39,7 @@ const Children = {
 		return children[0];
 	},
 	toArray(children) {
+		if (children === undefined || children === null) { return []; }
 		return Array.isArray && Array.isArray(children) ? children : ARR.concat(children);
 	}
 };


### PR DESCRIPTION
**Objective**

This PR aims to make Inferno-Compat identical to React.Children when called with undefined and null.
I tested the behavior on React and made Inferno-Compat do the same.
I wasn't able to find the file where this is tested though.

**Closes Issue**

It closes Issue #608 

**React's Behavior**

```
React.Children.map(undefined, () => {}) === undefined
React.Children.map(null, () => {}) === null
React.Children.forEach(undefined, () => {}) === undefined
React.Children.forEach(null, () => {}) === null
React.Children.count(undefined) === 0
React.Children.count(null) === 0
React.Children.toArray(undefined) === []
React.Children.toArray(null) === []
```

If you call React.Children.only wrongly it should throw...