### PR TITLE
fix global name for redux in UMD build

### DIFF
--- a/config/rollup.bundles.js
+++ b/config/rollup.bundles.js
@@ -96,7 +96,7 @@ bundles.add({
 		'inferno-create-element': 'Inferno.createElement',
 		'inferno-create-class': 'Inferno.createClass',
 		'path-to-regexp-es6': 'Inferno.pathToRegExp',
-		redux: 'redux'
+		redux: 'Redux'
 	},
 	path: 'packages/inferno-redux/'
 });


### PR DESCRIPTION
**Objective**

This PR fixes the global name for redux in the UMD build. (changed from `redux` to `Redux`)

**Closes Issue**

It closes Issue #623
